### PR TITLE
Cleanup github actions workflow and improve run duration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,9 @@
-# copied from: https://github.com/lukka/CppBuildTasks-Validation/blob/v10/.github/workflows/hosted-pure-workflow.yml
+# modified from: https://github.com/lukka/CppBuildTasks-Validation/blob/v10/.github/workflows/hosted-pure-workflow.yml
 
 # Copyright (c) 2021-2022 Luca Cappa
 # Released under the term specified in file LICENSE.txt
 # SPDX short identifier: MIT
 
-# A "pure" GitHub workflow using CMake, Ninja and vcpkg to build a C/C++ codebase.
-# It leverages both CMakePresets.json and vcpkg.json to have consistent build locallly
-# and on continuous integration servers (aka build agents).
-# It is called "pure workflow" because it is an example which minimizes the usage of
-# custom GitHub actions, but leverages directly the tools that could be easily run on
-# your development machines (i.e. CMake, vcpkg, Ninja) to ensure a perfectly identical
-# and reproducible build locally (on your development machine) and remotely (on build agents).
 name: uil
 on:
   push:
@@ -26,82 +19,67 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-24.04, windows-latest ]
         build: [ Release, Debug ]
         include:
           - os: windows-latest
             triplet: x64-windows
-            preset: ninja-multi-vcpkg
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             triplet: x64-linux
-            preset: ninja
     env:
-      # Tells vcpkg where binary packages are stored.
+      # Set vcpkg cache directories
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg_cache
+      X_VCPKG_REGISTRIES_CACHE: ${{ github.workspace }}/vcpkg_registry_cache
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
-      - name: "Create directory '${{ env.VCPKG_DEFAULT_BINARY_CACHE }}'"
-        run: mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
+      
+      - name: "Create vcpkg cache directories '${{ env.VCPKG_DEFAULT_BINARY_CACHE }}' and '${{ env.X_VCPKG_REGISTRIES_CACHE }}'"
         shell: bash
-      - name: "Install raylib Linux dependencies"
-        run: sudo apt install -yq libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa-dev pkg-config libgl1-mesa-dev libx11-dev libxcursor-dev libxinerama-dev libxrandr-dev libfmt-dev
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
+          mkdir -p $X_VCPKG_REGISTRIES_CACHE
 
-      # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
-      - uses: lukka/get-cmake@latest
-
-      # Restore both vcpkg and its artifacts from the GitHub cache service.
-      - name: Restore vcpkg and its artifacts.
-        uses: actions/cache@v3
+      - name: Restore vcpkg cache
+        uses: actions/cache@v4
         with:
-          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-          # The key is composed in a way that it gets properly invalidated: this must happen whenever vcpkg's Git commit id changes, or the list of packages changes. In this case a cache miss must happen and a new entry with a new key with be pushed to GitHub the cache service.
-          # The key includes: hash of the vcpkg.json file, the hash of the vcpkg Git commit id, and the used vcpkg's triplet. The vcpkg's commit id would suffice, but computing an hash out it does not harm.
-          # Note: given a key, the cache content is immutable. If a cache entry has been created improperly, in order the recreate the right content the key must be changed as well, and it must be brand new (i.e. not existing already).
+          path: |
+            ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+            ${{ env.X_VCPKG_REGISTRIES_CACHE }}
+          # The key is composed in a way that it gets properly invalidated: this must happen whenever vcpkg.json changes.
+          # In this case a cache miss must happen and a new entry with a new key with be pushed to GitHub the cache service.
+          # The key includes: hash of the vcpkg.json file and the used vcpkg's triplet.
+          # Note: given a key, the cache content is immutable. If a cache entry has been created improperly,
+          # in order the recreate the right content the key must be changed as well, and it must be brand new (i.e. not existing already).
           key: |
             ${{ hashFiles( 'vcpkg.json' ) }}-${{ matrix.triplet }}
+      
+      - name: "Install raylib Linux dependencies"
+        run: sudo apt install -yq libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa-dev pkg-config libgl1-mesa-dev libx11-dev libxcursor-dev libxinerama-dev libxrandr-dev libfmt-dev
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
 
-      - name: Show content of workspace after cache has been restored
-        run: find $RUNNER_WORKSPACE
-        shell: bash
+      # Setup the build machine with the most recent versions of CMake and Ninja.
+      # Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
+      - uses: lukka/get-cmake@latest
 
-      # On Windows runners, let's ensure to have the Developer Command Prompt environment setup correctly. As used here the Developer Command Prompt created is targeting x64 and using the default the Windows SDK.
+      # On Windows runners, let's ensure to have the Developer Command Prompt environment setup correctly.
+      # As used here the Developer Command Prompt created is targeting x64 and using the default the Windows SDK.
       - uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Install GCC 13
-        run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-          sudo apt-get update
-          sudo apt-get install -y gcc-13 g++-13
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+      # Run CMake to generate Ninja project files.
+      - name: CMake configure
+        run: cmake -S . -B build -G "Ninja" -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} -DCMAKE_INSTALL_PREFIX=INSTALL
 
-      # Run CMake to generate Ninja project files, using the vcpkg's toolchain file to resolve and install the dependencies as specified in vcpkg.json.
-      - name: Install dependencies and generate project files
-        run: |
-          cmake -S . -B build -G "Ninja" -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} -DCMAKE_INSTALL_PREFIX=INSTALL
-        working-directory: "${{ github.workspace }}"
-
-      # Build the whole project with Ninja (which is spawn by CMake).
+      # Run CMake to build the project.
       - name: Build ${{matrix.os}} / ${{matrix.build}}
-        run: |
-          cmake --build build --config ${{matrix.build}}
-        working-directory: "${{ github.workspace }}"
+        run: cmake --build build --config ${{matrix.build}}
 
-      # install the whole project
+      # Run CMake to install the project.
       - name: Install ${{matrix.os}} / ${{matrix.build}}
-        run: |
-          cmake --install build
-        working-directory: "${{ github.workspace }}"
+        run: cmake --install build
 
-      - name: Show content of workspace at its completion
-        run: find $RUNNER_WORKSPACE
-        shell: bash
-        
       - name: Test Suite
         run: ctest --test-dir build


### PR DESCRIPTION
Run duration for linux from ~2m50s down to ~1m and windows from ~3m down to ~2m.

- Adjusted comments, removed and reordered steps for readability
- Updated ubuntu runner to 24.04(Removes the need to install gcc-13 making the workflow faster)
- Added caching for the vcpkg registry cache
- Updated actions/checkout from v3 to v4
- Updated actions/cache from v3 to v4